### PR TITLE
Implement OAuth login flow with protected routes, global notifications, and loading states

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,7 +17,8 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-router": "^7.14.0",
-        "react-router-dom": "^7.14.0"
+        "react-router-dom": "^7.14.0",
+        "react-toastify": "^11.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -3500,6 +3501,19 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/react-transition-group": {

--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,8 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router": "^7.14.0",
-    "react-router-dom": "^7.14.0"
+    "react-router-dom": "^7.14.0",
+    "react-toastify": "^11.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,46 +1,103 @@
-import { useRoutes } from "react-router"
-import BodyLayout from "./layouts/BodyLayout"
+import { useEffect } from "react"
+import { Navigate, Outlet, useRoutes } from "react-router-dom"
 import Navbar from "./components/layout/Navbar"
 import Footer from "./components/layout/Footer"
+import BodyLayout from "./layouts/BodyLayout"
 import Projects from "./pages/Projects"
 import Login from "./pages/Login"
 import UserProfile from "./pages/UserProfile"
 import Community from "./pages/Community"
 import Network from "./pages/Network"
+import useAuthSession from "./hooks/useAuthSession"
+import LoadingSpinner from "./components/ui/LoadingSpinner"
+import NotificationProvider from "./components/ui/NotificationProvider"
+import { notifySuccess } from "./utils/notifications"
 
-function App() {
-
-	let element = useRoutes([
-		{
-			path: '/',
-			element: <Projects />
-		},
-		{
-			path: '/login',
-			element: <Login />
-		},
-		{
-			path: '/profile',
-			element: <UserProfile />
-		},
-		{
-			path: '/community',
-			element: <Community />
-		},
-		{
-			path: '/network',
-			element: <Network />
-		},
-	])
-
+const AppShell = () => {
 	return (
 		<div className="min-h-screen flex flex-col bg-app-bg dark:bg-app-bg">
 			<Navbar />
 			<main className="flex-1 w-full max-w-9/10 mx-auto px-4 sm:px-6 lg:px-8 py-4">
-				<BodyLayout element={element} />
+				<BodyLayout element={<Outlet />} />
 			</main>
 			<Footer />
 		</div>
+	)
+}
+
+const ProtectedRoute = ({ isAuthenticated, isChecking }) => {
+	if (isChecking) {
+		return <LoadingSpinner fullScreen />
+	}
+
+	if (!isAuthenticated) {
+		return <Navigate to="/login" replace />
+	}
+
+	return <AppShell />
+}
+
+const PublicRoute = ({ isAuthenticated, children }) => {
+	if (isAuthenticated) {
+		return <Navigate to="/" replace />
+	}
+
+	return children
+}
+
+function App() {
+	const { isAuthenticated, isChecking } = useAuthSession()
+
+	useEffect(() => {
+		if (isChecking || !isAuthenticated) {
+			return
+		}
+
+		const isPendingOAuthLogin = sessionStorage.getItem('oauth_login_pending') === '1'
+		if (isPendingOAuthLogin) {
+			sessionStorage.removeItem('oauth_login_pending')
+			notifySuccess('Successfully logged in!')
+		}
+	}, [isAuthenticated, isChecking])
+
+	const element = useRoutes([
+		{
+			path: '/login',
+			element: (
+				<PublicRoute isAuthenticated={isAuthenticated}>
+					<Login />
+				</PublicRoute>
+			)
+		},
+		{
+			path: '/',
+			element: <ProtectedRoute isAuthenticated={isAuthenticated} isChecking={isChecking} />,
+			children: [
+				{
+					index: true,
+					element: <Projects />
+				},
+				{
+					path: 'profile',
+					element: <UserProfile />
+				},
+				{
+					path: 'community',
+					element: <Community />
+				},
+				{
+					path: 'network',
+					element: <Network />
+				}
+			]
+		},
+	])
+
+	return (
+		<>
+			{element}
+			<NotificationProvider />
+		</>
 	)
 }
 

--- a/client/src/components/ui/LoadingSpinner.jsx
+++ b/client/src/components/ui/LoadingSpinner.jsx
@@ -1,0 +1,40 @@
+const sizeClasses = {
+	sm: 'h-5 w-5',
+	md: 'h-8 w-8',
+	lg: 'h-12 w-12'
+}
+
+const LoadingSpinner = ({  fullScreen = false, size = 'md', className = '' }) => {
+	const containerClasses = fullScreen
+		? 'min-h-screen flex items-center justify-center bg-app-bg text-text-primary'
+		: 'inline-flex items-center gap-3 text-text-primary'
+
+	return (
+		<div className={`${containerClasses} ${className}`.trim()} role="status" aria-live="polite" aria-busy="true">
+			<svg
+				className={`animate-spin ${sizeClasses[size] || sizeClasses.md}`}
+				viewBox="0 0 24 24"
+				fill="none"
+				aria-hidden="true"
+			>
+				<circle
+					className="opacity-20"
+					cx="12"
+					cy="12"
+					r="10"
+					stroke="currentColor"
+					strokeWidth="4"
+				/>
+				<path
+					className="opacity-80"
+					d="M22 12a10 10 0 0 0-10-10"
+					stroke="currentColor"
+					strokeWidth="4"
+					strokeLinecap="round"
+				/>
+			</svg>
+		</div>
+	)
+}
+
+export default LoadingSpinner

--- a/client/src/components/ui/NotificationProvider.jsx
+++ b/client/src/components/ui/NotificationProvider.jsx
@@ -1,0 +1,8 @@
+import { ToastContainer } from "react-toastify"
+import "react-toastify/dist/ReactToastify.css"
+
+const NotificationProvider = () => {
+	return <ToastContainer />
+}
+
+export default NotificationProvider

--- a/client/src/hooks/useAuthSession.jsx
+++ b/client/src/hooks/useAuthSession.jsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react"
+import authService from "../services/authService"
+
+const useAuthSession = () => {
+	const [isAuthenticated, setIsAuthenticated] = useState(false)
+	const [isChecking, setIsChecking] = useState(true)
+
+	useEffect(() => {
+		let isActive = true
+
+		const verifyAuthStatus = async () => {
+			try {
+				await authService.checkAuthStatus()
+				if (isActive) {
+					setIsAuthenticated(true)
+				}
+			} catch {
+				if (isActive) {
+					setIsAuthenticated(false)
+				}
+			} finally {
+				if (isActive) {
+					setIsChecking(false)
+				}
+			}
+		}
+
+		verifyAuthStatus()
+
+		return () => {
+			isActive = false
+		}
+	}, [])
+
+	return { isAuthenticated, isChecking }
+}
+
+export default useAuthSession

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,8 +1,48 @@
+import authService from "../services/authService"
+import { GitHub } from "@mui/icons-material"
+import codefolioDark from '../assets/logo/codefolio-dark.svg'
 
 const Login = () => {
+  const handleLogin = () => {
+    sessionStorage.setItem('oauth_login_pending', '1')
+    authService.loginWithGitHub()
+  }
+
   return (
-    <div className="px-4">
-      <h1>Login</h1>
+    <div className="fixed inset-0 overflow-hidden bg-app-bg p-4 md:p-6">
+      <div className="mx-auto flex h-full w-full max-w-6xl items-center">
+        <div className="hidden h-[86vh] w-[56%] items-center pr-6 lg:flex">
+          <img
+            src="https://picsum.photos/1200/1600"
+            alt="login background"
+            className="h-full w-full rounded-[2.25rem] object-cover"
+          />
+        </div>
+
+        <div className="flex w-full items-center justify-center lg:w-[44%]">
+          <div className="w-full max-w-md rounded-[2rem] border border-border bg-white/85 px-8 py-10 text-center shadow-[0_20px_60px_rgba(15,23,42,0.12)] backdrop-blur-sm dark:bg-slate-900/65 sm:px-10 sm:py-12">
+            <div className="space-y-3 text-center">
+              <img
+                src={codefolioDark}
+                alt="codefolio logo"
+                className="mx-auto mb-6 h-20 w-20"
+              />
+              <h1 className="text-3xl font-semibold tracking-tight">codefolio</h1>
+              <p className="text-sm sm:text-base text-text-secondary leading-6">
+                A platform built by developers <br />for developers
+              </p>
+            </div>
+
+            <button
+              onClick={handleLogin}
+              className="mt-8 inline-flex w-full items-center justify-center gap-3 rounded-full bg-black px-6 py-3 text-sm font-semibold text-white hover:!bg-black hover:!text-white"
+            >
+              <GitHub fontSize="small" />
+              Sign in with GitHub
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/client/src/utils/notifications.js
+++ b/client/src/utils/notifications.js
@@ -1,0 +1,24 @@
+import { toast } from "react-toastify"
+
+const defaultOptions = {
+	position: 'top-center',
+	autoClose: 3000,
+	hideProgressBar: true,
+	closeOnClick: true,
+	pauseOnHover: true,
+	draggable: true,
+	theme: 'light'
+}
+
+const notifySuccess = (message, options = {}) => toast.success(message, { ...defaultOptions, ...options })
+const notifyError = (message, options = {}) => toast.error(message, { ...defaultOptions, ...options })
+const notifyInfo = (message, options = {}) => toast.info(message, { ...defaultOptions, ...options })
+const notifyWarning = (message, options = {}) => toast.warn(message, { ...defaultOptions, ...options })
+
+export {
+	defaultOptions,
+	notifySuccess,
+	notifyError,
+	notifyInfo,
+	notifyWarning
+}


### PR DESCRIPTION
## Summary  
This PR fully wires the frontend login experience using GitHub OAuth and improves app-level auth UX.

## What was implemented  
1. Route protection and auth-aware navigation in `App.jsx`  
2. Public login route and protected app routes with redirect handling in `App.jsx`  
3. Session verification hook to determine authenticated state in `useAuthSession.jsx`  
4. Reusable loading spinner for auth-check/loading states in `LoadingSpinner.jsx`  
5. Login page wired to GitHub OAuth start, with pending-login marker before redirect in `Login.jsx`  
6. Global notification host for app-wide toast rendering in `NotificationProvider.jsx`  
7. Reusable notification helpers for success, error, info, and warning toasts in `notifications.js`  
8. One-time success toast after confirmed OAuth return in `App.jsx`

## Behavior after this PR  
1. Unauthenticated users are redirected to login when visiting protected routes  
2. Login button starts GitHub OAuth flow  
3. After successful OAuth return and session confirmation, user is routed into the app and sees a one-time success toast  
4. Loading spinner appears while auth status is being checked  

## Quick test plan  
1. Visit app while logged out and confirm redirect to login  
2. Click **Sign in with GitHub** on `Login.jsx` and complete OAuth  
3. Confirm successful redirect into protected routes and success toast appears once  
4. Refresh and confirm toast does not repeatedly show unless login flow is re-initiated  
5. Force auth failure and confirm redirect back to login works  

## Notes  
1. Notification infrastructure is now generic and reusable across the app for future error/success flows  
2. Toast rendering is mounted once globally via `NotificationProvider.jsx`

## Test Artifacts

https://github.com/user-attachments/assets/de71d052-37bc-4c54-83e0-32743efc100c