### PR TITLE
Add profile URL columns and align profile/network API fields

### DIFF
--- a/client/src/services/profileService.jsx
+++ b/client/src/services/profileService.jsx
@@ -20,7 +20,17 @@ const createProfile = async (profileData) => {
     }
 }
 
+const updateProfile = async (id, profileData) => {
+    try {
+        const response = await profile.patch(`/${id}`, profileData)
+        return response.data
+    } catch (err) {
+        throw new Error(err.response?.data?.message || 'Unable to update profile')
+    }
+}
+
 export default {
     getProfile,
-    createProfile
+    createProfile,
+    updateProfile
 }

--- a/server/config/reset.js
+++ b/server/config/reset.js
@@ -99,7 +99,9 @@ const createProfilesTable = async () => {
             user_id UUID UNIQUE REFERENCES users(id) ON DELETE CASCADE,
             bio TEXT,
             location TEXT,
-            links TEXT,
+            github_url TEXT,
+            linkedin_url TEXT,
+            other_url TEXT,
             created_at TIMESTAMP DEFAULT now()
         );
     `;

--- a/server/controllers/networkController.js
+++ b/server/controllers/networkController.js
@@ -20,7 +20,9 @@ const getProfileCardByProfileId = async (profileId) => {
         `SELECT p.id,
                 p.bio,
                 p.location,
-                p.links,
+                p.github_url,
+                p.linkedin_url,
+                p.other_url,
                 u.username,
                 u.avatar_url
          FROM profiles p
@@ -256,7 +258,9 @@ const getPendingRequests = async (req, res) => {
                     n.requester_id,
                     p.bio AS requester_bio,
                     p.location AS requester_location,
-                    p.links AS requester_links,
+                    p.github_url AS requester_github_url,
+                    p.linkedin_url AS requester_linkedin_url,
+                    p.other_url AS requester_other_url,
                     u.username AS requester_username,
                     u.avatar_url AS requester_avatar_url,
                     n.created_at
@@ -285,7 +289,9 @@ const getPendingRequests = async (req, res) => {
                 avatar_url: request.requester_avatar_url,
                 bio: request.requester_bio,
                 location: request.requester_location,
-                links: request.requester_links,
+                github_url: request.requester_github_url,
+                linkedin_url: request.requester_linkedin_url,
+                other_url: request.requester_other_url,
             },
         }));
 
@@ -337,9 +343,17 @@ const getAllConnections = async (req, res) => {
                         ELSE pr.location
                     END AS other_location,
                     CASE
-                        WHEN n.requester_id = $1 THEN pr2.links
-                        ELSE pr.links
-                    END AS other_links,
+                        WHEN n.requester_id = $1 THEN pr2.github_url
+                        ELSE pr.github_url
+                    END AS other_github_url,
+                    CASE
+                        WHEN n.requester_id = $1 THEN pr2.linkedin_url
+                        ELSE pr.linkedin_url
+                    END AS other_linkedin_url,
+                    CASE
+                        WHEN n.requester_id = $1 THEN pr2.other_url
+                        ELSE pr.other_url
+                    END AS other_other_url,
                     CASE
                         WHEN n.requester_id = $1 THEN u2.username
                         ELSE u1.username
@@ -376,7 +390,9 @@ const getAllConnections = async (req, res) => {
                 avatar_url: connection.other_avatar_url,
                 bio: connection.other_bio,
                 location: connection.other_location,
-                links: connection.other_links,
+                github_url: connection.other_github_url,
+                linkedin_url: connection.other_linkedin_url,
+                other_url: connection.other_other_url,
             },
         }));
 

--- a/server/controllers/profileController.js
+++ b/server/controllers/profileController.js
@@ -16,7 +16,7 @@ const getProfile = async (req, res) => {
 
 const createProfile = async (req, res) => {
     const userId = req.user?.id;
-    const {bio, location, links} = req.body;
+    const { bio, location, github_url, linkedin_url, other_url } = req.body;
 
     if (!userId) {
         return res.status(401).json({ message: 'Unauthorized' });
@@ -24,8 +24,10 @@ const createProfile = async (req, res) => {
 
     try {
         const newProfile = await pool.query(
-            `INSERT INTO profiles (user_id, bio, location, links) VALUES ($1, $2, $3, $4) RETURNING *`,
-            [userId, bio, location, links]
+            `INSERT INTO profiles (user_id, bio, location, github_url, linkedin_url, other_url)
+             VALUES ($1, $2, $3, $4, $5, $6)
+             RETURNING *`,
+            [userId, bio, location, github_url, linkedin_url, other_url]
         );
         res.status(201).json(newProfile.rows[0]);
     }
@@ -34,7 +36,34 @@ const createProfile = async (req, res) => {
     }
 }
 
+const updateprofile = async (req, res) => {
+    const id = req.params.id;
+    const { bio, location, github_url, linkedin_url, other_url } = req.body;
+
+    try {
+        const updatedProfile = await pool.query(
+            `UPDATE profiles
+             SET bio = $1,
+                 location = $2,
+                 github_url = $3,
+                 linkedin_url = $4,
+                 other_url = $5
+             WHERE id = $6
+             RETURNING *`,
+            [bio, location, github_url, linkedin_url, other_url, id]
+        );
+        if (updatedProfile.rows.length === 0) {
+            return res.status(404).json({ message: 'Profile not found' });
+        }
+        res.status(200).json(updatedProfile.rows[0]);
+    }
+    catch (err) {
+        res.status(409).json({ message: 'Error updating profile', error: err.message });    
+    }
+}
+
 export default {
     getProfile,
-    createProfile
+    createProfile,
+    updateprofile
 }

--- a/server/migrations/20260416_add_profile_links_columns.js
+++ b/server/migrations/20260416_add_profile_links_columns.js
@@ -1,0 +1,8 @@
+export const up = async (client) => {
+    await client.query(`
+        ALTER TABLE profiles
+        ADD COLUMN IF NOT EXISTS github_url TEXT,
+        ADD COLUMN IF NOT EXISTS linkedin_url TEXT,
+        ADD COLUMN IF NOT EXISTS other_url TEXT;
+    `);
+};

--- a/server/routes/allRoutes.js
+++ b/server/routes/allRoutes.js
@@ -22,6 +22,7 @@ router.get('/hashtags/search', postController.searchHashtags);
 
 router.get('/profiles/:id', profileController.getProfile);
 router.post('/profiles', isAuthenticated, profileController.createProfile);
+router.patch('/profiles/:id', isAuthenticated, profileController.updateprofile);
 
 router.post('/network/requests', isAuthenticated, networkController.sendRequest);
 router.patch('/network/requests/:networkId/accept', isAuthenticated, networkController.acceptRequest);


### PR DESCRIPTION
## Description  
This PR introduces dedicated profile URL fields and updates backend profile-related responses to use them.

## What changed  

- Added migration to create new profile URL columns:  
  `20260416_add_profile_links_columns.js`  

- Updated profile create/update logic to use:  
  - `github_url`  
  - `linkedin_url`  
  - `other_url`  
  in:  
  `profileController.js`  

- Updated network profile payload/query shape to return the new URL fields instead of the old `links` field:  
  `networkController.js`  

- Reset schema for fresh DB setup reflects the new profile columns:  
  `reset.js`  

## Scope note  

- This PR does **not** remove the legacy `profiles.links` column from the live database  
- This PR does **not** include data backfill  
- Rollback migration is intentionally deferred  

## How to run  

From repo root:

```bash
npm --prefix server run migrate
```

## Optional Status Check
```bash
npm --prefix server run migrate:status
```